### PR TITLE
fix: `extra-platforms` is of type list on NixOS

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -12,10 +12,7 @@ let
   # cf. https://stackoverflow.com/q/78649070/55246
   supportedSystems =
     let
-      extra-systems =
-        if lib.hasAttr "extra-platforms" config.nix.settings
-        then lib.strings.splitString " " config.nix.settings.extra-platforms
-        else [ ];
+      extra-systems = config.nix.settings.extra-platforms or [ ];
       host-system = config.nixpkgs.hostPlatform.system;
     in
     lib.unique ([ host-system ] ++ extra-systems);

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -12,7 +12,13 @@ let
   # cf. https://stackoverflow.com/q/78649070/55246
   supportedSystems =
     let
-      extra-systems = config.nix.settings.extra-platforms or [ ];
+      extra-systems =
+        # on Darwin, nix.conf's extra-platforms is a string, as opposed to a list (as on NixOS)
+        if isDarwin
+        then if lib.hasAttr "extra-platforms" config.nix.settings
+        then lib.strings.splitString " " config.nix.settings.extra-platforms
+        else [ ]
+        else config.nix.settings.extra-platforms or [ ];
       host-system = config.nixpkgs.hostPlatform.system;
     in
     lib.unique ([ host-system ] ++ extra-systems);


### PR DESCRIPTION
While it is a string on nix-darwin.

See https://github.com/juspay/nixos-buffet/pull/40#issuecomment-2402858506